### PR TITLE
fix: page.tsxの`queryFn`でServer Actionsを利用しないようにする

### DIFF
--- a/src/actions/useUserInfo.ts
+++ b/src/actions/useUserInfo.ts
@@ -1,25 +1,8 @@
 'use server';
 
-import { authOptions } from '@/lib/auth/authOptions';
 import prisma from '@/lib/prisma/prisma';
-import { getServerSession } from 'next-auth';
 
-export const getUserInfo = async () => {
-  // const session = await getServerSession(authOptions);
-  // const id = session?.user.id;
-  const user = await prisma.user.findMany();
-  // if (id) {
-  //   return { ...session.user };
-  // } else {
-  //   return null;
-  // }
-  if (user !== null) {
-    return user;
-  } else {
-    return null;
-  }
-};
-
+/** ユーザー情報 */
 export type UserInfo = {
   id: string;
   name: string;
@@ -28,12 +11,32 @@ export type UserInfo = {
   image: string;
 };
 
+/**
+ * Server Actions
+ *
+ * ユーザー情報一覧を取得する
+ */
+export const getUserInfo = async () => {
+  const user = await prisma.user.findMany();
+  if (user !== null) {
+    return user;
+  } else {
+    return null;
+  }
+};
+
+/** ユーザー登録情報 */
 export type SetUserInfo = {
   name: string;
   email: string;
   emailVerified: Date;
 };
 
+/**
+ * Server Actions
+ *
+ * ユーザー情報を登録する
+ */
 export const setUserInfo = async ({ name, email, emailVerified }: SetUserInfo) => {
   await prisma.user.create({
     data: {

--- a/src/app/components/ReactQueryTest.tsx
+++ b/src/app/components/ReactQueryTest.tsx
@@ -8,9 +8,7 @@ export const ReactQueryTest = ({ queryKey }: { queryKey: [string] }) => {
   const { userInfo, mutation } = useUserInfo(queryKey);
   const [qStateData] = useQState<string>(['qState'], 'qState test');
 
-  // console.log('userInfo after mutate', userInfo);
-  // console.log('isPending in client component', isPending);
-  // console.log('qStateData in client component', qStateData);
+  console.log('ReactQueryTest, userInfo', userInfo);
 
   return (
     <>

--- a/src/app/components/ReactQueryTestWrapper.tsx
+++ b/src/app/components/ReactQueryTestWrapper.tsx
@@ -1,15 +1,10 @@
 'use client';
 
-import { useState } from 'react';
 import { ReactQueryTest } from './ReactQueryTest';
-import { setUserInfo } from '@/actions/useUserInfo';
 import { useUserInfo } from '@/hooks/useUserInfo';
 
 export const ReactQueryTestWrapper = ({ initialQueryKey }: { initialQueryKey: [string] }) => {
   const { mutation } = useUserInfo(initialQueryKey);
-  // const [queryKey, setQueryKey] = useState<[string]>(initialQueryKey);
-
-  // const onClickChangeQueryKey = () => setQueryKey((prevState) => (prevState[0] === 'test' ? ['test2'] : ['test']));
 
   const onClickRandomCreateUser = async () => {
     const uuid = crypto.randomUUID();
@@ -23,17 +18,10 @@ export const ReactQueryTestWrapper = ({ initialQueryKey }: { initialQueryKey: [s
 
   return (
     <>
-      {/* {!mutation.isSuccess ? (
-        <p>loading...</p>
-      ) : (
-        <> */}
       <ReactQueryTest queryKey={initialQueryKey} />
-      {/* </>
-      )} */}
       <div>
         <button onClick={onClickRandomCreateUser}>ユーザーランダム生成</button>
       </div>
-      <div>{/* <button onClick={onClickChangeQueryKey}>Query Key 切り替え</button> */}</div>
     </>
   );
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import './globals.css';
 import Provider from './Provider';
 import Header from '@/components/layout/Header';
 import { dehydratedState } from '@/lib/react-query/dehydratedState';
-import { getUserInfo } from '@/actions/useUserInfo';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -19,8 +18,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     queryKey: ['todo2'],
     path: '/api/todo2',
   });
-
-  // const initialUserInfo = await getUserInfo();
 
   return (
     <html lang="ja">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { ReactQueryTestWrapper } from './components/ReactQueryTestWrapper';
 import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query';
 import getQueryClient from '@/lib/react-query/getQueryClient';
+import prisma from '@/lib/prisma/prisma';
 
 export default async function Page() {
   const queryClient = getQueryClient();
@@ -18,7 +19,8 @@ export default async function Page() {
   await queryClient.prefetchQuery({
     queryKey,
     queryFn: async () => {
-      return await getUserInfo();
+      const user = await prisma.user.findMany();
+      return user;
     },
   });
   /* const todo = await fetcher<Todo[]>(

--- a/src/app/react-query/page.tsx
+++ b/src/app/react-query/page.tsx
@@ -1,9 +1,9 @@
-import { getUserInfo } from '@/actions/useUserInfo';
 import Link from 'next/link';
 import React from 'react';
 import { ReactQueryTestWrapper } from '../components/ReactQueryTestWrapper';
-import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query';
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import getQueryClient from '@/lib/react-query/getQueryClient';
+import prisma from '@/lib/prisma/prisma';
 
 export default async function Page() {
   const queryClient = getQueryClient();
@@ -12,7 +12,10 @@ export default async function Page() {
 
   await queryClient.prefetchQuery({
     queryKey,
-    queryFn: getUserInfo,
+    queryFn: async () => {
+      const user = await prisma.user.findMany();
+      return user;
+    },
   });
 
   // const [count, setCount] = useQState(['count'], 1);
@@ -32,5 +35,3 @@ export default async function Page() {
     </HydrationBoundary>
   );
 }
-
-// export default Page;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -18,11 +18,11 @@ function Header() {
         <div className="flex items-center ml-auto">
           {userInfo && userInfo.length > 0 ? (
             <div className="flex space-x-4 items-center">
-              {/* {userInfo[0].image ? (
+              {userInfo[0].image ? (
                 <Image src={userInfo[0].image} width={40} height={40} alt="プロフィール画像" className="w-12 circle" />
               ) : (
                 <VscAccount className="" size={'40'} />
-              )} */}
+              )}
             </div>
           ) : (
             <SignInDialog />

--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -16,11 +16,9 @@ export const useUserInfo = (initialQueryKey: [string]) => {
     // queryFn: async () => {
     //   return await getUserInfo();
     // },
-    // initialData: queryClient.getQueryData(queryKey) as UserInfo[],
   });
 
-  console.log('data', data);
-  console.log('isPending', isPending);
+  console.log('useUserInfo data', data);
 
   const mutation = useMutation({
     mutationFn: setUserInfo,


### PR DESCRIPTION
## 変更内容

- コメントの修正
- 対象のpage.tsxの`queryFn`をServer Actionsからprismaのメソッドを実行するように変更
  - https://github.com/jbtaku/todo/pull/7/files#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3b
  - https://github.com/jbtaku/todo/pull/7/files#diff-a86c10fc33130c6e5f6108dea044adf09fa6c8fbb1c1bd2b2cf8e01b15fb9a85